### PR TITLE
Support compilation with MinGW toolchain

### DIFF
--- a/src/bytestreamin_file.hpp
+++ b/src/bytestreamin_file.hpp
@@ -132,8 +132,10 @@ inline BOOL ByteStreamInFile::isSeekable() const
 
 inline I64 ByteStreamInFile::tell() const
 {
-#ifdef _WIN32
+#if defined _WIN32 && ! defined (__MINGW32__)
   return _ftelli64(file);
+#elif defined (__MINGW32__)
+  return (I64)ftello64(file);
 #else
   return (I64)ftello(file);
 #endif
@@ -141,8 +143,10 @@ inline I64 ByteStreamInFile::tell() const
 
 inline BOOL ByteStreamInFile::seek(const I64 position)
 {
-#ifdef _WIN32
+#if defined _WIN32 && ! defined (__MINGW32__)
   return !(_fseeki64(file, position, SEEK_SET));
+#elif defined (__MINGW32__)
+  return !(fseeko64(file, (off_t)position, SEEK_SET));
 #else
   return !(fseeko(file, (off_t)position, SEEK_SET));
 #endif
@@ -150,8 +154,10 @@ inline BOOL ByteStreamInFile::seek(const I64 position)
 
 inline BOOL ByteStreamInFile::seekEnd(const I64 distance)
 {
-#ifdef _WIN32
+#if defined _WIN32 && ! defined (__MINGW32__)
   return !(_fseeki64(file, -distance, SEEK_END));
+#elif defined (__MINGW32__)
+  return !(fseeko64(file, (off_t)-distance, SEEK_END));
 #else
   return !(fseeko(file, (off_t)-distance, SEEK_END));
 #endif

--- a/src/bytestreamout_file.hpp
+++ b/src/bytestreamout_file.hpp
@@ -133,8 +133,10 @@ inline BOOL ByteStreamOutFile::isSeekable() const
 
 inline I64 ByteStreamOutFile::tell() const
 {
-#ifdef _WIN32
+#if defined _WIN32 && ! defined (__MINGW32__)
   return _ftelli64(file);
+#elif defined (__MINGW32__)
+  return (I64)ftello64(file);
 #else
   return (I64)ftello(file);
 #endif
@@ -142,8 +144,10 @@ inline I64 ByteStreamOutFile::tell() const
 
 inline BOOL ByteStreamOutFile::seek(I64 position)
 {
-#ifdef _WIN32
+#if defined _WIN32 && ! defined (__MINGW32__)
   return !(_fseeki64(file, position, SEEK_SET));
+#elif defined (__MINGW32__)
+  return !(fseeko64(file, (off_t)position, SEEK_SET));
 #else
   return !(fseeko(file, (off_t)position, SEEK_SET));
 #endif
@@ -151,8 +155,10 @@ inline BOOL ByteStreamOutFile::seek(I64 position)
 
 inline BOOL ByteStreamOutFile::seekEnd()
 {
-#ifdef _WIN32
+#if defined _WIN32 && ! defined (__MINGW32__)
   return !(_fseeki64(file, 0, SEEK_END));
+#elif defined (__MINGW32__)
+  return !(fseeko64(file, (off_t)0, SEEK_END));
 #else
   return !(fseeko(file, (off_t)0, SEEK_END));
 #endif

--- a/src/mydefs.hpp
+++ b/src/mydefs.hpp
@@ -40,7 +40,7 @@ typedef unsigned int       U32;
 typedef unsigned short     U16;
 typedef unsigned char      U8;
 
-#if defined(_WIN32)            // 64 byte integer under Windows 
+#if defined(_WIN32) && ! defined (__MINGW32__) // 64 byte integer under Windows 
 typedef unsigned __int64   U64;
 typedef __int64            I64;
 #else                          // 64 byte integer elsewhere ... 


### PR DESCRIPTION
Trying to compile LASzip on Windows using MinGW fails, but changing a few preprocessor directives fixes that (at least for me it does). Tested with a recent MinGW32 and MinGW64 on a x86-64 host.
