### PR TITLE
Include the dll directory as an include directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,7 +74,7 @@ source_group("Header Files" FILES ${LASZIP_HPP})
 source_group("Source Files" FILES ${LASZIP_CPP})
 
 # Standard include directory of laszip library
-include_directories(../include ../include/laszip .)
+include_directories(../include ../include/laszip ../dll .)
 
 
 if(BUILD_STATIC)


### PR DESCRIPTION
Without dll/, build fails with "'laszip_dll.h' file not found.
