### PR TITLE
Don't use the std namespace in the global space

### DIFF
--- a/include/laszip/lasunzipper.hpp
+++ b/include/laszip/lasunzipper.hpp
@@ -43,7 +43,6 @@
 #else
 #include <istream>
 #include <fstream>
-using namespace std;
 #endif
 
 class ByteStreamIn;
@@ -53,7 +52,7 @@ class LASZIP_DLL LASunzipper
 {
 public:
   bool open(FILE* file, const LASzip* laszip);
-  bool open(istream& stream, const LASzip* laszip);
+  bool open(std::istream& stream, const LASzip* laszip);
  
   unsigned int tell() const;
   bool seek(const unsigned int position);

--- a/include/laszip/laszipper.hpp
+++ b/include/laszip/laszipper.hpp
@@ -44,7 +44,6 @@
 #else
 #include <istream>
 #include <fstream>
-using namespace std;
 #endif
 
 class ByteStreamOut;
@@ -54,7 +53,7 @@ class LASZIP_DLL LASzipper
 {
 public:
   bool open(FILE* outfile, const LASzip* laszip);
-  bool open(ostream& outstream, const LASzip* laszip);
+  bool open(std::ostream& outstream, const LASzip* laszip);
 
   bool write(const unsigned char* const * point);
   bool chunk();


### PR DESCRIPTION
Doing `using namespace std;` inside the global namespace is A Bad Thing, and doing so could (does) break implicit namespace resolution in other packages.

@hobu this fixes the problem with the rivlib library that we discussed via email — however, it seems as though Riegl should be explicit with their own array class as well so it isn't this easy to break their stuff.
