### PR TITLE
Correct headers location in OSGeo4W deploying

### DIFF
--- a/cmake/modules/BuildOSGeo4W.cmake
+++ b/cmake/modules/BuildOSGeo4W.cmake
@@ -55,7 +55,6 @@ add_dependencies( copy make_osgeo4w_directories  )
 macro(copy_files GLOBPAT DESTINATION  )
 
     file(GLOB_RECURSE COPY_FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}
         ${GLOBPAT})
     foreach(FILENAME ${COPY_FILES})
         set(SRC "${FILENAME}")
@@ -90,7 +89,7 @@ endmacro(tar_directories)
 make_directories()
 copy_files(${LASZIP_BUILD_OUTPUT_DIRECTORY}/laszip.dll ${OSGEO4W_BIN_DIR}/  )
 copy_files(${LASZIP_BUILD_OUTPUT_DIRECTORY}/laszip.lib ${OSGEO4W_LIB_DIR}/  )
-copy_files(./include/laszip/*.hpp ${OSGEO4W_INCLUDE_DIR}/  )
+copy_files(${laszip_SOURCE_DIR}/include/laszip/*.hpp ${OSGEO4W_INCLUDE_DIR}/  )
 
 tar_directories(${OSGEO4W_DIR} ${laszip_SOURCE_DIR}/${OSGEO4W_PACKAGES}/laszip-${VERSION}-${OSGEO4W_UPSTREAM_RELEASE}.tar.bz2 "bin/;lib/;include/")
 


### PR DESCRIPTION
Do not use location relative to build directory, but to source directory.

This solves the problem manifesting with error like this while building on Windows with VS:

```
[ 93%] Copying OSGeo4W files
Error copying file "./include/laszip/lasunzipper.hpp" to "osgeo4w/include/laszip/".
NMAKE : fatal error U1077: 'echo' : return code '0x1'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\BIN\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\BIN\nmake.exe"' : return code '0x2'
Stop.
```
