### PR TITLE
keep Makefile.am in sync with cmake file

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,8 +29,6 @@ liblibrary_la_SOURCES =				arithmeticmodel.cpp \
                         bytestreamout.hpp \
                         bytestreamout_file.hpp \
                         bytestreamout_ostream.hpp \
-                        entropydecoder.hpp \
-                        entropyencoder.hpp \
                         lasreaditemraw.hpp \
                         lasreaditem.hpp \
                         laswriteitem.hpp \


### PR DESCRIPTION
The entropy files where removed from the cmake file but not from the automake file. Which caused an error during make tags. 
