### PR TITLE
Switch Travis to Trusty 14.04.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 # Configure Travis CI service for http://github.com/LASzip
 language: cpp
 
+sudo: required
+dist: trusty
+
 compiler:
   - g++
   - clang


### PR DESCRIPTION
Upgrades to Trusty 14.04 VM image for Travis-CI testing, which has  cmake 2.8.12.  This is compatible with the current build system's requirements.  See issue #20 for more details and why the test fails.