### PR TITLE
Fixes for compilation w/clang OSX. Fix for VLR header stream.

### DIFF
--- a/dll/laszip_api.c
+++ b/dll/laszip_api.c
@@ -759,19 +759,19 @@ laszip_exploit_spatial_index
 typedef laszip_I32 (*laszip_decompress_selective_def)
 (
     laszip_POINTER                     pointer
-    , const laszip_BOOL                exploit
+    , const laszip_U32                 decompress_selective
 );
 laszip_decompress_selective_def laszip_decompress_selective_ptr = 0;
 LASZIP_API laszip_I32
 laszip_decompress_selective
 (
     laszip_POINTER                     pointer
-    , const laszip_BOOL                exploit
+    , const laszip_U32                 decompress_selective
 )
 {
   if (laszip_decompress_selective_ptr)
   {
-    return (*laszip_decompress_selective_ptr)(pointer, exploit);
+    return (*laszip_decompress_selective_ptr)(pointer, decompress_selective);
   }
   return 1;
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,47 +7,7 @@
 ###############################################################################
 set(LASZIP_HEADERS_DIR ../include/laszip)
 
-set(LASZIP_HPP
-    arithmeticdecoder.hpp
-    arithmeticencoder.hpp
-    arithmeticmodel.hpp
-    bytestreamin.hpp
-    bytestreamin_array.hpp
-    bytestreamin_file.hpp
-    bytestreamin_istream.hpp
-    bytestreaminout.hpp
-    bytestreaminout_file.hpp
-    bytestreamout.hpp
-    bytestreamout_array.hpp
-    bytestreamout_file.hpp
-    bytestreamout_nil.hpp
-    bytestreamout_ostream.hpp
-    endian.hpp
-    integercompressor.hpp
-    lasattributer.hpp
-    lasindex.hpp
-    lasinterval.hpp
-    laspoint.hpp
-    lasquadtree.hpp
-    lasquantizer.hpp
-    lasreaditem.hpp
-    lasreaditemcompressed_v1.hpp
-    lasreaditemcompressed_v2.hpp
-    lasreaditemraw.hpp
-    lasreadpoint.hpp
-    #lasunzipper.hpp
-    laswriteitem.hpp
-    laswriteitemcompressed_v1.hpp
-    laswriteitemcompressed_v2.hpp
-    laswriteitemraw.hpp
-    laswritepoint.hpp
-    laszip.hpp
-    laszip_common_v1.hpp
-    laszip_common_v2.hpp
-    mydefs.hpp
- )
-
-set(LASZIP_CPP
+set(LASZIP_SOURCES
     arithmeticdecoder.cpp
     arithmeticencoder.cpp
     arithmeticmodel.cpp
@@ -57,10 +17,12 @@ set(LASZIP_CPP
     lasquadtree.cpp
     lasreaditemcompressed_v1.cpp
     lasreaditemcompressed_v2.cpp
+    lasreaditemcompressed_v3.cpp
     lasreadpoint.cpp
     #lasunzipper.cpp
     laswriteitemcompressed_v1.cpp
     laswriteitemcompressed_v2.cpp
+    laswriteitemcompressed_v3.cpp
     laswritepoint.cpp
     laszip.cpp
     laszip_dll.cpp
@@ -68,11 +30,6 @@ set(LASZIP_CPP
 
 add_definitions(-DUNORDERED)
 add_definitions(-DLASZIPDLL_EXPORTS)
-
-set(LASZIP_SOURCES
-  ${LASZIP_HPP}
-  ${LASZIP_CPP}
-  )
 
 LASZIP_ADD_LIBRARY(${LASZIP_BASE_LIB_NAME} ${LASZIP_SOURCES})
 

--- a/src/laszip_dll.cpp
+++ b/src/laszip_dll.cpp
@@ -28,7 +28,7 @@
    29 July 2017 -- integrating minimal stream-based reading/writing into branch
    20 July 2017 -- Andrew Bell adds support for stream-based reading/writing
    28 May 2017 -- support for "LAS 1.4 selective decompression" added into DLL API
-   25 April 2017 -- adding initial support for new "native LAS 1.4 extension" 
+   25 April 2017 -- adding initial support for new "native LAS 1.4 extension"
     8 January 2017 -- changed from "laszip_dll.h" to "laszip_api.h" for hobu
 
 ===============================================================================
@@ -678,7 +678,7 @@ laszip_set_point_type_and_size(
     }
 
     // check if point type and type are supported
-    
+
     if (!LASzip().setup(point_type, point_size, LASZIP_COMPRESSOR_NONE))
     {
       sprintf(laszip_dll->error, "invalid combination of point_type %d and point_size %d", (I32)point_type, (I32)point_size);
@@ -2007,7 +2007,7 @@ laszip_open_writer(
 #ifdef _WIN32
           sprintf(laszip_dll->error, "inconsistent number_of_point_records %u and extended_number_of_point_records %I64d", laszip_dll->header.number_of_point_records, laszip_dll->header.extended_number_of_point_records);
 #else
-          sprintf(laszip_dll->error, "inconsistent number_of_point_records %u and extended_number_of_point_records %%llu", laszip_dll->header.number_of_point_records, laszip_dll->header.extended_number_of_point_records);
+          sprintf(laszip_dll->error, "inconsistent number_of_point_records %u and extended_number_of_point_records %llu", laszip_dll->header.number_of_point_records, laszip_dll->header.extended_number_of_point_records);
 #endif
 	return 1;
         }
@@ -2360,7 +2360,7 @@ laszip_open_writer(
     {
       return 1;
     }
-    
+
     // open the file
 
     laszip_dll->file = fopen(file_name, "wb");
@@ -2594,7 +2594,7 @@ laszip_open_writer(
           sprintf(laszip_dll->warning, "header.start_of_waveform_data_packet_record is %llu. writing 0 instead.", laszip_dll->header.start_of_waveform_data_packet_record);
 #endif
           laszip_dll->header.start_of_waveform_data_packet_record = 0;
-        }                  
+        }
         try { laszip_dll->streamout->put64bitsLE((U8*)&(laszip_dll->header.start_of_waveform_data_packet_record)); } catch(...)
         {
           sprintf(laszip_dll->error, "writing header.start_of_waveform_data_packet_record");
@@ -3864,7 +3864,7 @@ static laszip_I32 laszip_read_header(
 #ifdef _WIN32
             fprintf(stderr,"WARNING: number_of_point_records is %u. but extended_number_of_point_records is %I64d.\n", laszip_dll->header.number_of_point_records, number_of_extended_variable_length_records);
 #else
-            fprintf(stderr,"WARNING: number_of_point_records is %u. but extended_number_of_point_records is %llu.\n", laszip_dll->header.number_of_point_records, number_of_extended_variable_length_records);
+            fprintf(stderr,"WARNING: number_of_point_records is %u. but extended_number_of_point_records is %u.\n", laszip_dll->header.number_of_point_records, number_of_extended_variable_length_records);
 #endif
           }
           laszip_dll->header.extended_number_of_point_records = extended_number_of_point_records;
@@ -4338,7 +4338,7 @@ laszip_read_point(
       flags_and_channel = point->extra_bytes[laszip_dll->start_flags_and_channel];
       if (laszip_dll->start_NIR_band != -1)
       {
-        ((U16)(point->rgb[3])) = *((U16*)(point->extra_bytes + laszip_dll->start_NIR_band));
+        point->rgb[3] = *((U16*)(point->extra_bytes + laszip_dll->start_NIR_band));
       }
 
       // decompose into individual attributes
@@ -4574,7 +4574,7 @@ laszip_I32 create_point_writer
 }
 
 /*---------------------------------------------------------------------------*/
-// The stream writer also supports software that writes the LAS header on its 
+// The stream writer also supports software that writes the LAS header on its
 // own simply by setting the BOOL 'do_not_write_header' to TRUE. This function
 // should then be called just prior to writing points as data is then written
 // to the current stream position
@@ -4634,7 +4634,7 @@ laszip_open_writer_stream(
   }
   laszip_dll->error[0] = '\0';
   return 0;
-} 
+}
 
 /*---------------------------------------------------------------------------*/
 // make LASzip VLR for given point type and size (always request native LAS 1.4 extension)
@@ -4656,7 +4656,7 @@ laszip_create_laszip_vlr(
   }
 
   ByteStreamOutArray* out = 0;
-  
+
   if (IS_LITTLE_ENDIAN())
     out = new ByteStreamOutArrayLE();
   else

--- a/src/laszip_dll.cpp
+++ b/src/laszip_dll.cpp
@@ -1725,7 +1725,7 @@ static laszip_I32 write_laszip_vlr_header(
     return 1;
   }
   U16 record_length_after_header = (U16)laszip_vrl_payload_size(laszip);
-  try { laszip_dll->streamout->put16bitsLE((U8*)&record_length_after_header); } catch(...)
+  try { out->put16bitsLE((U8*)&record_length_after_header); } catch(...)
   {
     sprintf(laszip_dll->error, "writing LASzip VLR header.record_length_after_header");
     return 1;
@@ -1733,7 +1733,7 @@ static laszip_I32 write_laszip_vlr_header(
   CHAR description[32];
   memset(description, 0, 32);
   sprintf(description, "LASzip DLL %d.%d r%d (%d)", LASZIP_VERSION_MAJOR, LASZIP_VERSION_MINOR, LASZIP_VERSION_REVISION, LASZIP_VERSION_BUILD_DATE);
-  try { laszip_dll->streamout->putBytes((U8*)description, 32); } catch(...)
+  try { out->putBytes((U8*)description, 32); } catch(...)
   {
     sprintf(laszip_dll->error, "writing LASzip VLR header.description");
     return 1;


### PR DESCRIPTION
These changes allow laszip to pass PDAL compression/decompression tests.