### PR TITLE
Load .so dll on non-apple

### DIFF
--- a/dll/laszip_api.c
+++ b/dll/laszip_api.c
@@ -958,8 +958,10 @@ laszip_I32 laszip_load_dll()
   // Load DLL file
 #ifdef _WIN32
   laszip_HINSTANCE = LoadLibrary(TEXT("LASzip.dll"));
-#else
+#elif __APPLE__
   laszip_HINSTANCE = LoadLibrary("liblaszip.dylib", RTLD_NOW);
+#else
+  laszip_HINSTANCE = LoadLibrary("liblaszip.so", RTLD_NOW);
 #endif
   if (laszip_HINSTANCE == NULL) {
      return 1;


### PR DESCRIPTION
This platform checking is...dubious...but this was the Minimum Required To Work on a Debian system.