### PR TITLE
Fix install path for laszip_api_version.h

### DIFF
--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -176,7 +176,7 @@ macro(SET_INSTALL_DIRS)
           set(LASZIP_LIB_INSTALL_DIR "lib")
       endif()
   endif ()
-    set(LASZIP_INCLUDE_INSTALL_ROOT "include/")
+    set(LASZIP_INCLUDE_INSTALL_ROOT "include")
     set(LASZIP_INCLUDE_INSTALL_DIR
         "${LASZIP_INCLUDE_INSTALL_ROOT}")
     set(LASZIP_DOC_INCLUDE_DIR

--- a/dll/CMakeLists.txt
+++ b/dll/CMakeLists.txt
@@ -10,7 +10,7 @@ install(DIRECTORY "${LASZIP_HEADERS_DIR}"
         PATTERN "/CMakeFiles/*" EXCLUDE
 )
 
-install(DIRECTORY "${CMAKE_BINARY_DIR}/include/laszip/"
+install(DIRECTORY "${CMAKE_BINARY_DIR}/include/laszip"
         DESTINATION "${LASZIP_INCLUDE_INSTALL_DIR}"
         PATTERN "/CMakeFiles/*" EXCLUDE
 )


### PR DESCRIPTION
A trailing slash on the source directory path was causing laszip_api_version.h to be installed to the include root instead of the `laszip` subdirectory. This was breaking PDAL's laszip autodetection.

There's also a small tweak to the root install path, removing a trailing slash that was causing double-slashes. Just an aesthetic change.