### PR TITLE
Append CXXFLAGS instead of overwriting them.

### DIFF
--- a/cmake/unix_compiler_options.cmake
+++ b/cmake/unix_compiler_options.cmake
@@ -19,4 +19,4 @@ else()
     message(FATAL_ERROR "Unsupported C++ compiler")
 endif()
 
-set (CMAKE_CXX_FLAGS "${LASZIP_COMMON_CXX_FLAGS} ${CXX_STANDARD}")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LASZIP_COMMON_CXX_FLAGS} ${CXX_STANDARD}")


### PR DESCRIPTION
This preserves hardening buildflags set in the environment.