### PR TITLE
Free point_items in setup_laszip_items if needed.

### DIFF
--- a/src/laszip_dll.cpp
+++ b/src/laszip_dll.cpp
@@ -2794,6 +2794,7 @@ setup_laszip_items(
 
   // compute offsets (or points item pointers) for data transfer from the point items
 
+  if (laszip_dll->point_items) delete [] laszip_dll->point_items;
   laszip_dll->point_items = new U8*[laszip->num_items];
   if (laszip_dll->point_items == 0)
   {

--- a/src/laszip_dll.cpp
+++ b/src/laszip_dll.cpp
@@ -2794,7 +2794,7 @@ setup_laszip_items(
 
   // compute offsets (or points item pointers) for data transfer from the point items
 
-  if (laszip_dll->point_items) delete [] laszip_dll->point_items;
+  delete [] laszip_dll->point_items;
   laszip_dll->point_items = new U8*[laszip->num_items];
   if (laszip_dll->point_items == 0)
   {


### PR DESCRIPTION
Found via valgrind.  The solution in this PR follows the model a few lines below [here](https://github.com/connormanning/LASzip/blob/5a6cc82fa42ced311ff5d150847a2cea9edebe87/src/laszip_dll.cpp#L2824), which calls `delete` and reallocates with `new` if the pointer contents already exist.

Not sure if a better solution would be to reuse the existing `point_items` if it is non-null rather than reallocating:
```
  if (!laszip_dll->point_items) laszip_dll->point_items = new U8*[laszip->num_items];
```

It could also be that neither of these are necessarily correct and instead it is an underlying issue that the `point_items` may not be cleaned up in all cases.