### PR TITLE
Free ByteStreamOutArray data in destructor if it hasn't been taken.

### DIFF
--- a/src/bytestreamout_array.hpp
+++ b/src/bytestreamout_array.hpp
@@ -53,7 +53,7 @@ public:
 /* seek to the end of the file                               */
   BOOL seekEnd();
 /* destructor                                                */
-  ~ByteStreamOutArray(){};
+  ~ByteStreamOutArray(){ if (data) free(data); };
 /* get access to data                                        */
   inline I64 getSize() const { return size; };
   inline I64 getCurr() const { return curr; };

--- a/src/bytestreamout_array.hpp
+++ b/src/bytestreamout_array.hpp
@@ -53,7 +53,7 @@ public:
 /* seek to the end of the file                               */
   BOOL seekEnd();
 /* destructor                                                */
-  ~ByteStreamOutArray(){ if (data) free(data); };
+  ~ByteStreamOutArray(){ free(data); };
 /* get access to data                                        */
   inline I64 getSize() const { return size; };
   inline I64 getCurr() const { return curr; };


### PR DESCRIPTION
Found via valgrind.  I'm not positive that this is the proper fix, or whether the underlying cause for `takeData` not being called needs to be investigated.