### PR TITLE
Set compability mode when writing uncompressed LAS

### DIFF
--- a/src/laszip_dll.cpp
+++ b/src/laszip_dll.cpp
@@ -2775,7 +2775,7 @@ setup_laszip_items(
   laszip_U8 point_type = laszip_dll->header.point_data_format;
   laszip_U16 point_size = laszip_dll->header.point_data_record_length;
 
-  if (compress && (point_type > 5) && laszip_dll->request_compatibility_mode)
+  if ((point_type > 5) && laszip_dll->request_compatibility_mode)
   {
     if (!laszip->request_compatibility_mode(1))
     {


### PR DESCRIPTION
Previously the compressed flag has been checked when setting the
compatibility mode. This caused later in the code, that no memory for
extra_bytes was allocated, and subsequently, a segmentation fault error
when writing out points uncompressed AND in compatibility mode. It seems
that compatibility should work with uncompressed data as example 7 of
laszipdllexample.cpp suggests.

Possible fix for: #59