### PR TITLE
[fix][memory-leak] fixes memory leak in `laszip_dll.cpp`:`laszip_prepare_point_for_write`

### DIFF
--- a/src/laszip_dll.cpp
+++ b/src/laszip_dll.cpp
@@ -2046,7 +2046,7 @@ laszip_prepare_point_for_write(
 
       // add the compatibility VLR
 
-      if (laszip_add_vlr(laszip_dll, "lascompatible\0\0", 22204, (laszip_U16)(2+2+4+148), 0, (laszip_U8*)out->takeData()))
+      if (laszip_add_vlr(laszip_dll, "lascompatible\0\0", 22204, (laszip_U16)(2+2+4+148), 0, (laszip_U8*)out->getData()))
       {
         sprintf(laszip_dll->error, "adding the compatibility VLR");
         return 1;


### PR DESCRIPTION
## Short description 

1. source: data is `malloc`'d in `ByteStreamOutArray` constructor
2. then taken from that class instance in 'laszip_prepare_point_for_write'
3. passed to `laszip_add_vlr`
4. ... (and never freed)

## resolution

(1-liner)

instead of taking ownership of the data, it's only borrowed. It is then tracked and delete with the `ByteStreamOutArray` destructor.

## Valgrind output 

example output from valgrind run on example/laszipdllexample.cpp -> EXAMPLE_NINE
```
==178339== Memcheck, a memory error detector
==178339== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==178339== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==178339== Command: bin/dllexample placeholder example.out.laz
==178339==
LASzip DLL v3.4 r3 (build 191111)
running EXAMPLE_NINE (writing LAS 1.4 points with "extra bytes" *with* compatibility to compressed LAZ *and* also uncompressed LAS)
offset_to_point_data before adding 'height above ground' is : 375
offset_to_point_data before adding 'coverage count' is      : 621
offset_to_point_data before adding  empty OGC WKT VLR is    : 813
offset_to_point_data before adding funny VLR is             : 867
offset_to_point_data after adding VLRs                      : 921
writing file 'example.out.laz' compressed
successfully written 5 points
total time: 0.189563 sec for writing compressed
==178339==
==178339== HEAP SUMMARY:
==178339==     in use at exit: 4,096 bytes in 1 blocks
==178339==   total heap usage: 627 allocs, 626 frees, 490,792 bytes allocated
==178339==
==178339== 4,096 bytes in 1 blocks are definitely lost in loss record 1 of 1
==178339==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==178339==    by 0x48C8107: ByteStreamOutArray::ByteStreamOutArray(long long) (in /home/dwilliams/project/laszip/build/lib/liblaszip.so.8.0.5)
==178339==    by 0x48C83B6: ByteStreamOutArrayLE::ByteStreamOutArrayLE(long long) (in /home/dwilliams/project/laszip/build/lib/liblaszip.so.8.0.5)
==178339==    by 0x48E1948: laszip_prepare_point_for_write(laszip_dll*, int) (in /home/dwilliams/project/laszip/build/lib/liblaszip.so.8.0.5)
==178339==    by 0x48E5194: laszip_open_writer (in /home/dwilliams/project/laszip/build/lib/liblaszip.so.8.0.5)
==178339==    by 0x10A054: main (in /home/dwilliams/project/laszip/build/bin/dllexample)
==178339==
==178339== LEAK SUMMARY:
==178339==    definitely lost: 4,096 bytes in 1 blocks
==178339==    indirectly lost: 0 bytes in 0 blocks
==178339==      possibly lost: 0 bytes in 0 blocks
==178339==    still reachable: 0 bytes in 0 blocks
==178339==         suppressed: 0 bytes in 0 blocks
==178339==
==178339== For lists of detected and suppressed errors, rerun with: -s
==178339== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

The cause was that the memory allocated by the ByteStreamOutArray was taken later in the 'laszip_prepare_point_for_write' function then passed to 'laszip_add_vlr';
the problem is that laszip_add_vlr doesn't expect to own its pointers, so it never freed them.