### PR TITLE
fix small memory leak

### DIFF
--- a/src/lasreaditemcompressed_v3.cpp
+++ b/src/lasreaditemcompressed_v3.cpp
@@ -207,6 +207,7 @@ LASreadItemCompressed_POINT14_v3::~LASreadItemCompressed_POINT14_v3()
     delete dec_intensity;
     delete dec_scan_angle;
     delete dec_user_data;
+    delete dec_point_source;
     delete dec_gps_time;
 
     delete instream_channel_returns_XY;
@@ -216,6 +217,7 @@ LASreadItemCompressed_POINT14_v3::~LASreadItemCompressed_POINT14_v3()
     delete instream_intensity;
     delete instream_scan_angle;
     delete instream_user_data;
+    delete instream_point_source;
     delete instream_gps_time;
   }
 

--- a/src/lasreaditemcompressed_v3.hpp
+++ b/src/lasreaditemcompressed_v3.hpp
@@ -24,6 +24,7 @@
   
   CHANGE HISTORY:
   
+    30 December 2021 -- fix small memory leak
     19 March 2019 -- set "legacy classification" to zero if "classification > 31"  
     28 August 2017 -- moving 'context' from global development hack to interface  
     19 April 2017 -- support for selective decompression for new LAS 1.4 points 


### PR DESCRIPTION
memory leak in src/lasreaditemcompressed_v3.cpp, dec_point_source and instream_point_source is not freed.