### PR TITLE
Fix: ArithmeticEncoder: Early-out for done() when writing already finished

### DIFF
--- a/src/arithmeticencoder.cpp
+++ b/src/arithmeticencoder.cpp
@@ -100,8 +100,6 @@
 
 #include <stdio.h>
 
-FILE* file = 0;
-
 #include "arithmeticmodel.hpp"
 
 ArithmeticEncoder::ArithmeticEncoder()
@@ -130,6 +128,8 @@ BOOL ArithmeticEncoder::init(ByteStreamOut* outstream)
 
 void ArithmeticEncoder::done()
 {
+  if (outstream == 0) return;
+
   U32 init_base = base;                 // done encoding: set final data bytes
   BOOL another_byte = TRUE;
 
@@ -347,6 +347,7 @@ inline void ArithmeticEncoder::renorm_enc_interval()
 
 inline void ArithmeticEncoder::manage_outbuffer()
 {
+  assert(outstream);
   if (outbyte == endbuffer) outbyte = outbuffer;
   outstream->putBytes(outbyte, AC_BUFFER_SIZE);
   endbyte = outbyte + AC_BUFFER_SIZE;


### PR DESCRIPTION
We came across a crash in the situation that the output device is out of space and writing fails with an I/O error.
It appears that `ArithmeticEncoder::done` can be called more than once and we should early-out rather than doing the cleanup again.

For reproducing this issue I used a 1MB ramdisk and tried to write a 2MB LAZ file there via LasZip.
