### PR TITLE
LASwritePoint: error-out for I/O error rather than continuing

### DIFF
--- a/src/laswritepoint.cpp
+++ b/src/laswritepoint.cpp
@@ -336,14 +336,20 @@ BOOL LASwritePoint::write(const U8 * const * point)
   {
     for (i = 0; i < num_writers; i++)
     {
-      writers[i]->write(point[i], context);
+      if (!writers[i]->write(point[i], context))
+      {
+        return FALSE;
+      }
     }
   }
   else
   {
     for (i = 0; i < num_writers; i++)
     {
-      writers_raw[i]->write(point[i], context);
+      if (!writers_raw[i]->write(point[i], context))
+      {
+        return FALSE;
+      }
       ((LASwriteItemCompressed*)(writers_compressed[i]))->init(point[i], context);
     }
     writers = writers_compressed;


### PR DESCRIPTION
We see crashes for outputting LAS (not compressed) to an out-of-space device.
This appears to be due to `LASwritePoint::write` not actually checking the return value from `LASwriteItem::write`.
With this fix, no crash.