### PR TITLE
Single (3) / first (1) / last (2) / intermediate (0) context is fixed

### DIFF
--- a/src/lasreaditemcompressed_v3.cpp
+++ b/src/lasreaditemcompressed_v3.cpp
@@ -850,8 +850,8 @@ inline void LASreadItemCompressed_POINT14_v3::read(U8* item, U32& context)
 
   // create single (3) / first (1) / last (2) / intermediate (0) return context for current point
 
-  I32 cpr = (r == 1 ? 2 : 0); // first ?
-  cpr += (r >= n ? 1 : 0); // last ?
+  I32 cpr = (r == 1 ? 1 : 0); // first ?
+  cpr += (r >= n ? 2 : 0); // last ?
 
   U32 k_bits;
   I32 median, diff;

--- a/src/lasreaditemcompressed_v4.cpp
+++ b/src/lasreaditemcompressed_v4.cpp
@@ -848,8 +848,8 @@ inline void LASreadItemCompressed_POINT14_v4::read(U8* item, U32& context)
 
   // create single (3) / first (1) / last (2) / intermediate (0) return context for current point
 
-  I32 cpr = (r == 1 ? 2 : 0); // first ?
-  cpr += (r >= n ? 1 : 0); // last ?
+  I32 cpr = (r == 1 ? 1 : 0); // first ?
+  cpr += (r >= n ? 2 : 0); // last ?
 
   U32 k_bits;
   I32 median, diff;

--- a/src/laswriteitemcompressed_v3.cpp
+++ b/src/laswriteitemcompressed_v3.cpp
@@ -615,8 +615,8 @@ inline BOOL LASwriteItemCompressed_POINT14_v3::write(const U8* item, U32& contex
 
   // create single (3) / first (1) / last (2) / intermediate (0) return context for current point
 
-  I32 cpr = (r == 1 ? 2 : 0); // first ?
-  cpr += (r >= n ? 1 : 0); // last ?
+  I32 cpr = (r == 1 ? 1 : 0); // first ?
+  cpr += (r >= n ? 2 : 0); // last ?
 
   U32 k_bits;
   I32 median, diff;

--- a/src/laswriteitemcompressed_v4.cpp
+++ b/src/laswriteitemcompressed_v4.cpp
@@ -613,8 +613,8 @@ inline BOOL LASwriteItemCompressed_POINT14_v4::write(const U8* item, U32& contex
 
   // create single (3) / first (1) / last (2) / intermediate (0) return context for current point
 
-  I32 cpr = (r == 1 ? 2 : 0); // first ?
-  cpr += (r >= n ? 1 : 0); // last ?
+  I32 cpr = (r == 1 ? 1 : 0); // first ?
+  cpr += (r >= n ? 2 : 0); // last ?
 
   U32 k_bits;
   I32 median, diff;


### PR DESCRIPTION
Does not affect the result.