### PR TITLE
Reflect license change in lasmessage files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ set(LASZIP_SOURCES
     laszip.cpp
     laszip_dll.cpp
     mydefs.cpp
-	lasmessage.cpp
+    lasmessage.cpp
 )
 
 add_definitions(-DLASZIPDLL_EXPORTS)

--- a/src/lasmessage.cpp
+++ b/src/lasmessage.cpp
@@ -1,6 +1,36 @@
+/*
+===============================================================================
+
+  FILE:  lasmessage.cpp
+
+  CONTENTS:
+
+    see corresponding header file
+
+  PROGRAMMERS:
+
+    info@rapidlasso.de  -  https://rapidlasso.de
+
+  COPYRIGHT:
+
+    (c) 2007-2024, rapidlasso GmbH - fast tools to catch reality
+
+    This is free software; you can redistribute and/or modify it under the
+    terms of the Apache Public License 2.0 published by the Apache Software
+    Foundation. See the COPYING file for more information.
+
+    This software is distributed WITHOUT ANY WARRANTY and without even the
+    implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+  CHANGE HISTORY:
+
+    see corresponding header file
+
+===============================================================================
+*/
 #include "lasmessage.hpp"
 #include <stdio.h>
-#include <stdarg.h> 
+#include <stdarg.h>
 #include <string>
 #include <assert.h>
 

--- a/src/lasmessage.hpp
+++ b/src/lasmessage.hpp
@@ -13,18 +13,18 @@
 
   COPYRIGHT:
 
-    (c) 2007-2019, rapidlasso GmbH - fast tools to catch reality
+    (c) 2007-2024, rapidlasso GmbH - fast tools to catch reality
 
     This is free software; you can redistribute and/or modify it under the
-    terms of the GNU Lesser General Licence as published by the Free Software
-    Foundation. See the LICENSE.txt file for more information.
+    terms of the Apache Public License 2.0 published by the Apache Software
+    Foundation. See the COPYING file for more information.
 
     This software is distributed WITHOUT ANY WARRANTY and without even the
     implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
   CHANGE HISTORY:
 
-    07 Februar 2024 -- intial version
+    07 Februar 2024 -- initial version
 
 ===============================================================================
 */
@@ -60,10 +60,10 @@ enum LAS_MESSAGE_TYPE {
 #else
 /** wrap the format argument of a printf-like function */
 # define LAS_FORMAT_STRING(arg) arg
-#endif 
+#endif
 
 
-// central las message function 
+// central las message function
 void LASLIB_DLL LASMessage(LAS_MESSAGE_TYPE type, LAS_FORMAT_STRING(const char*), ...);
 
 // special debug message function that will be removed in release mode
@@ -73,25 +73,25 @@ void LASLIB_DLL LASMessage(LAS_MESSAGE_TYPE type, LAS_FORMAT_STRING(const char*)
 #define LASDebug(...)  /* skip debug message in release mode at compile time. */
 #endif
 
-// The default laslib messsage handler outputs message to stderr. Per default all message types below info
-// will be skipped. Using set_default_message_log_level the log level can be changed/increased. 
+// The default laslib message handler outputs message to stderr. Per default all message types below info
+// will be skipped. Using set_default_message_log_level the log level can be changed/increased.
 
-// set log level of default laslib message handler (default = LAS_INFO). This also affect a costum message
+// set log level of default laslib message handler (default = LAS_INFO). This also affect a custom message
 // handler which can be set by set_las_message_handler. Use LAS_QUIET to disable any output
 void LASLIB_DLL set_message_log_level(LAS_MESSAGE_TYPE loglevel);
 // get log level of default laslib message handler
 LAS_MESSAGE_TYPE LASLIB_DLL get_message_log_level();
 
 
-// callback function type for overwritting the default laslib message handler
+// callback function type for overwriting the default laslib message handler
 typedef void  (*LASMessageHandler)(LAS_MESSAGE_TYPE type, const char* msg, void* user_data);
 
-// set a new costum message handler (the user data pointer will be passed to the callback)
+// set a new custom message handler (the user data pointer will be passed to the callback)
 void LASLIB_DLL set_las_message_handler(LASMessageHandler callback, void* user_data = 0);
 // restore the default laslib message handler
 void LASLIB_DLL unset_las_message_handler();
 
-// @brief Logger-Wrapper that alloes to stream to the logger.
+// @brief Logger-Wrapper that allows to stream to the logger.
 // @usage LASMessageStream(LAS_FATAL_ERROR) << "Pi is approximately: " << LASMessageStream().precision(2) << 3.14159 << std::endl;
 class LASMessageStream
 {


### PR DESCRIPTION
When the license was changed by 8d82288effd827ee90bcb2f1f24cb3cc49026f5c, the lasmessage files (introduced by 7a918c29a7d3bdef3bb1036e10468d3cdb05529e) did not get this change.