### PR TITLE
Use string literal for format string

### DIFF
--- a/src/lasmessage.cpp
+++ b/src/lasmessage.cpp
@@ -139,8 +139,8 @@ void las_default_message_handler(LAS_MESSAGE_TYPE type, const char* msg, void* u
 	if (!prefix.empty())
 	{
 		format_message(message, (unsigned)prefix.size());
-		fprintf(stderr, prefix.c_str());
-		fprintf(stderr, message.c_str());
+		fprintf(stderr, "%s", prefix.c_str());
+		fprintf(stderr, "%s", message.c_str());
 	}
 	else
 	{


### PR DESCRIPTION
Fixes
~~~
/src/lasmessage.cpp:142:19: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
                fprintf(stderr, prefix.c_str());
                                ^~~~~~~~~~~~~~
/src/3.4.4-3a2924fd94.clean/src/lasmessage.cpp:142:19: note: treat the string as an argument to avoid this
                fprintf(stderr, prefix.c_str());
                                ^
                                "%s", 
~~~