### PR TITLE
Expose LASMessage functions to LASzip API

### DIFF
--- a/dll/laszip_api.c
+++ b/dll/laszip_api.c
@@ -106,6 +106,90 @@ laszip_clean
 };
 
 /*---------------------------------------------------------------------------*/
+typedef laszip_I32 (*laszip_set_error_handler_def)
+(
+    laszip_POINTER                     pointer
+    , laszip_message_handler           callback
+    , void*                            user_data
+);
+laszip_set_error_handler_def laszip_set_error_handler_ptr = 0;
+LASZIP_API laszip_I32
+laszip_set_error_handler
+(
+    laszip_POINTER                     pointer
+    , laszip_message_handler           callback
+    , void*                            user_data
+)
+{
+  if (laszip_set_error_handler_ptr)
+  {
+    return (*laszip_set_error_handler_ptr)(pointer, callback, user_data);
+  }
+  return 1;
+};
+
+/*---------------------------------------------------------------------------*/
+typedef laszip_I32 (*laszip_unset_las_message_handler_def)
+(
+    laszip_POINTER                     pointer
+);
+laszip_unset_las_message_handler_def laszip_unset_las_message_handler_ptr = 0;
+LASZIP_API laszip_I32
+laszip_unset_las_message_handler
+(
+    laszip_POINTER                     pointer
+)
+{
+  if (laszip_unset_las_message_handler_ptr)
+  {
+    return (*laszip_unset_las_message_handler_ptr)(pointer);
+  }
+  return 1;
+};
+
+/*---------------------------------------------------------------------------*/
+typedef laszip_I32 (*laszip_set_las_message_log_level_def)
+(
+    laszip_POINTER                     pointer
+    , enum LAS_MESSAGE_TYPE            type
+);
+laszip_set_las_message_log_level_def laszip_set_las_message_log_level_ptr = 0;
+LASZIP_API laszip_I32
+laszip_set_las_message_log_level
+(
+    laszip_POINTER                     pointer
+    , enum LAS_MESSAGE_TYPE            type
+)
+{
+  if (laszip_set_las_message_log_level_ptr)
+  {
+    return (*laszip_set_las_message_log_level)(pointer, type);
+  }
+  return 1;
+};
+
+/*---------------------------------------------------------------------------*/
+typedef laszip_I32 (*laszip_get_las_message_log_level_def)
+(
+    laszip_POINTER                     pointer
+    , enum LAS_MESSAGE_TYPE*           type
+);
+laszip_get_las_message_log_level_def laszip_get_las_message_log_level_ptr = 0;
+LASZIP_API laszip_I32
+laszip_get_las_message_log_level
+(
+    laszip_POINTER                     pointer
+    , enum LAS_MESSAGE_TYPE*           type
+)
+{
+  if (laszip_get_las_message_log_level_ptr)
+  {
+    return (*laszip_get_las_message_log_level_ptr)(pointer, type);
+  }
+  return 1;
+};
+
+/*---------------------------------------------------------------------------*/
 typedef laszip_I32 (*laszip_get_error_def)
 (
     laszip_POINTER                     pointer

--- a/dll/laszip_api.h
+++ b/dll/laszip_api.h
@@ -219,6 +219,26 @@ typedef struct laszip_point
 
 } laszip_point_struct;
 
+enum laszip_message_type
+{
+  laszip_DEBUG = 0
+  , laszip_VERY_VERBOSE
+  , laszip_VERBOSE
+  , laszip_INFO
+  , laszip_WARNING
+  , laszip_SERIOUS_WARNING
+  , laszip_ERROR
+  , laszip_FATAL_ERROR
+};
+
+typedef void(*laszip_message_handler)(
+  enum laszip_message_type             type
+  , const char*                        msg
+  , void*                              user_data
+);
+
+/**
+
 /*---------------------------------------------------------------------------*/
 /*------ DLL constants for selective decompression via LASzip DLL -----------*/
 /*---------------------------------------------------------------------------*/
@@ -265,6 +285,38 @@ laszip_get_version
 LASZIP_API laszip_I32
 laszip_create(
     laszip_POINTER*                    pointer
+);
+
+/*---------------------------------------------------------------------------*/
+LASZIP_API laszip_I32
+laszip_set_las_message_handler
+(
+    laszip_POINTER*                    pointer
+    , laszip_message_handler           callback
+    , void*                            user_data
+);
+
+/*---------------------------------------------------------------------------*/
+LASZIP_API laszip_I32
+laszip_unset_las_message_handler
+(
+    laszip_POINTER*                    pointer
+);
+
+/*---------------------------------------------------------------------------*/
+LASZIP_API laszip_I32
+laszip_set_las_message_log_level
+(
+    laszip_POINTER                     pointer
+    , enum laszip_message_type         log_level
+);
+
+/*---------------------------------------------------------------------------*/
+LASZIP_API laszip_I32
+laszip_get_las_message_log_level
+(
+    laszip_POINTER                     pointer
+    , enum laszip_message_type*        log_level
 );
 
 /*---------------------------------------------------------------------------*/

--- a/dll/laszip_api.h
+++ b/dll/laszip_api.h
@@ -70,6 +70,8 @@
 #   define LASZIP_API
 #endif
 
+#include <laszip/laszip_common.h>
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -84,7 +86,7 @@ typedef int                laszip_BOOL;
 typedef char               laszip_CHAR;
 typedef float              laszip_F32;
 typedef double             laszip_F64;
-typedef void* laszip_POINTER;
+typedef void*              laszip_POINTER;
 #ifdef _WIN32
 typedef unsigned char      laszip_U8;
 typedef unsigned short     laszip_U16;
@@ -219,25 +221,11 @@ typedef struct laszip_point
 
 } laszip_point_struct;
 
-enum laszip_message_type
-{
-  laszip_DEBUG = 0
-  , laszip_VERY_VERBOSE
-  , laszip_VERBOSE
-  , laszip_INFO
-  , laszip_WARNING
-  , laszip_SERIOUS_WARNING
-  , laszip_ERROR
-  , laszip_FATAL_ERROR
-};
-
 typedef void(*laszip_message_handler)(
-  enum laszip_message_type             type
+  enum LAS_MESSAGE_TYPE                type
   , const char*                        msg
   , void*                              user_data
 );
-
-/**
 
 /*---------------------------------------------------------------------------*/
 /*------ DLL constants for selective decompression via LASzip DLL -----------*/
@@ -273,8 +261,7 @@ typedef void(*laszip_message_handler)(
 
 /*---------------------------------------------------------------------------*/
 LASZIP_API laszip_I32
-laszip_get_version
-(
+laszip_get_version(
     laszip_U8*                         version_major
     , laszip_U8*                       version_minor
     , laszip_U16*                      version_revision
@@ -289,48 +276,42 @@ laszip_create(
 
 /*---------------------------------------------------------------------------*/
 LASZIP_API laszip_I32
-laszip_set_las_message_handler
-(
-    laszip_POINTER*                    pointer
+laszip_set_las_message_handler(
+    laszip_POINTER                     pointer
     , laszip_message_handler           callback
     , void*                            user_data
 );
 
 /*---------------------------------------------------------------------------*/
 LASZIP_API laszip_I32
-laszip_unset_las_message_handler
-(
-    laszip_POINTER*                    pointer
-);
-
-/*---------------------------------------------------------------------------*/
-LASZIP_API laszip_I32
-laszip_set_las_message_log_level
-(
+laszip_unset_las_message_handler(
     laszip_POINTER                     pointer
-    , enum laszip_message_type         log_level
 );
 
 /*---------------------------------------------------------------------------*/
 LASZIP_API laszip_I32
-laszip_get_las_message_log_level
-(
+laszip_set_las_message_log_level(
     laszip_POINTER                     pointer
-    , enum laszip_message_type*        log_level
+    , enum LAS_MESSAGE_TYPE            type
 );
 
 /*---------------------------------------------------------------------------*/
 LASZIP_API laszip_I32
-laszip_get_error
-(
+laszip_get_las_message_log_level(
+    laszip_POINTER                     pointer
+    , enum LAS_MESSAGE_TYPE*           type
+);
+
+/*---------------------------------------------------------------------------*/
+LASZIP_API laszip_I32
+laszip_get_error(
     laszip_POINTER                     pointer
     , laszip_CHAR**                    error
 );
 
 /*---------------------------------------------------------------------------*/
 LASZIP_API laszip_I32
-laszip_get_warning
-(
+laszip_get_warning(
     laszip_POINTER                     pointer
     , laszip_CHAR**                    warning
 );
@@ -615,14 +596,12 @@ laszip_close_reader(
 
 /*---------------------------------------------------------------------------*/
 LASZIP_API laszip_I32
-laszip_load_dll
-(
+laszip_load_dll(
 );
 
 /*---------------------------------------------------------------------------*/
 LASZIP_API laszip_I32
-laszip_unload_dll
-(
+laszip_unload_dll(
 );
 
 #ifdef __cplusplus

--- a/include/laszip/laszip_common.h
+++ b/include/laszip/laszip_common.h
@@ -32,10 +32,6 @@
 #ifndef LASZIP_COMMON_H
 #define LASZIP_COMMON_H
 
-#include <sstream>
-#include <string>
-#include <iomanip>
-
 /// maximum length of
 #define LAS_MAX_MESSAGE_LENGTH 8192
 

--- a/src/laszip_dll.cpp
+++ b/src/laszip_dll.cpp
@@ -251,42 +251,14 @@ laszip_message_func(
   if (laszip_dll->message_callback_data == 0) return;
   if (laszip_dll->message_callback_data->callback == 0) return;
 
-  enum laszip_message_type message_type;
-  switch (type)
-  {
-  case LAS_MESSAGE_TYPE::LAS_DEBUG:
-    message_type = laszip_message_type::laszip_DEBUG;
-    break;
-  case LAS_MESSAGE_TYPE::LAS_VERY_VERBOSE:
-    message_type = laszip_message_type::laszip_VERY_VERBOSE;
-    break;
-  case LAS_MESSAGE_TYPE::LAS_VERBOSE:
-    message_type = laszip_message_type::laszip_VERBOSE;
-    break;
-  case LAS_MESSAGE_TYPE::LAS_INFO:
-    message_type = laszip_message_type::laszip_INFO;
-    break;
-  case LAS_MESSAGE_TYPE::LAS_WARNING:
-    message_type = laszip_message_type::laszip_WARNING;
-    break;
-  case LAS_MESSAGE_TYPE::LAS_SERIOUS_WARNING:
-    message_type = laszip_message_type::laszip_SERIOUS_WARNING;
-    break;
-  case LAS_MESSAGE_TYPE::LAS_ERROR:
-    message_type = laszip_message_type::laszip_ERROR;
-    break;
-  case LAS_MESSAGE_TYPE::LAS_FATAL_ERROR:
-    message_type = laszip_message_type::laszip_FATAL_ERROR;
-    break;
-  }
   laszip_dll->message_callback_data->callback(
-    message_type, msg, laszip_dll->message_callback_data->user_data);
+    type, msg, laszip_dll->message_callback_data->user_data);
 }
 
 /*---------------------------------------------------------------------------*/
 LASZIP_API laszip_I32
 laszip_set_error_handler(
-    laszip_POINTER*                    pointer
+    laszip_POINTER                     pointer
     , laszip_message_handler           callback
     , void*                            user_data
 )
@@ -323,7 +295,7 @@ laszip_set_error_handler(
 LASZIP_API laszip_I32
 laszip_unset_las_message_handler
 (
-    laszip_POINTER*                    pointer
+    laszip_POINTER                     pointer
 )
 {
   if (pointer == 0) return 1;
@@ -351,7 +323,7 @@ LASZIP_API laszip_I32
 laszip_set_las_message_log_level
 (
     laszip_POINTER                     pointer
-    , enum laszip_message_type         log_level
+    , enum LAS_MESSAGE_TYPE            type
 )
 {
   if (pointer == 0) return 1;
@@ -359,35 +331,7 @@ laszip_set_las_message_log_level
 
   try
   {
-    enum LAS_MESSAGE_TYPE message_type;
-    switch (log_level)
-    {
-    case laszip_message_type::laszip_DEBUG:
-      message_type = LAS_MESSAGE_TYPE::LAS_DEBUG;
-      break;
-    case laszip_message_type::laszip_VERY_VERBOSE:
-      message_type = LAS_MESSAGE_TYPE::LAS_VERY_VERBOSE;
-      break;
-    case laszip_message_type::laszip_VERBOSE:
-      message_type = LAS_MESSAGE_TYPE::LAS_VERBOSE;
-      break;
-    case laszip_message_type::laszip_INFO:
-      message_type = LAS_MESSAGE_TYPE::LAS_INFO;
-      break;
-    case laszip_message_type::laszip_WARNING:
-      message_type = LAS_MESSAGE_TYPE::LAS_WARNING;
-      break;
-    case laszip_message_type::laszip_SERIOUS_WARNING:
-      message_type = LAS_MESSAGE_TYPE::LAS_SERIOUS_WARNING;
-      break;
-    case laszip_message_type::laszip_ERROR:
-      message_type = LAS_MESSAGE_TYPE::LAS_ERROR;
-      break;
-    case laszip_message_type::laszip_FATAL_ERROR:
-      message_type = LAS_MESSAGE_TYPE::LAS_FATAL_ERROR;
-      break;
-    }
-    set_message_log_level(message_type);
+    set_message_log_level(type);
   }
   catch (...)
   {
@@ -403,43 +347,16 @@ LASZIP_API laszip_I32
 laszip_get_las_message_log_level
 (
     laszip_POINTER                     pointer
-    , enum laszip_message_type*        log_level
+    , enum LAS_MESSAGE_TYPE*           type
 )
 {
   if (pointer == 0) return 1;
   laszip_dll_struct* laszip_dll = (laszip_dll_struct*)pointer;
-  if (log_level == 0) return 1;
+  if (type == 0) return 1;
 
   try
   {
-    enum LAS_MESSAGE_TYPE message_type = get_message_log_level();
-    switch (message_type)
-    {
-    case LAS_MESSAGE_TYPE::LAS_DEBUG:
-      *log_level = laszip_message_type::laszip_DEBUG;
-      break;
-    case LAS_MESSAGE_TYPE::LAS_VERY_VERBOSE:
-      *log_level = laszip_message_type::laszip_VERY_VERBOSE;
-      break;
-    case LAS_MESSAGE_TYPE::LAS_VERBOSE:
-      *log_level = laszip_message_type::laszip_VERBOSE;
-      break;
-    case LAS_MESSAGE_TYPE::LAS_INFO:
-      *log_level = laszip_message_type::laszip_INFO;
-      break;
-    case LAS_MESSAGE_TYPE::LAS_WARNING:
-      *log_level = laszip_message_type::laszip_WARNING;
-      break;
-    case LAS_MESSAGE_TYPE::LAS_SERIOUS_WARNING:
-      *log_level = laszip_message_type::laszip_SERIOUS_WARNING;
-      break;
-    case LAS_MESSAGE_TYPE::LAS_ERROR:
-      *log_level = laszip_message_type::laszip_ERROR;
-      break;
-    case LAS_MESSAGE_TYPE::LAS_FATAL_ERROR:
-      *log_level = laszip_message_type::laszip_FATAL_ERROR;
-      break;
-    }
+    *type = get_message_log_level();
   }
   catch (...)
   {

--- a/src/laszip_dll.cpp
+++ b/src/laszip_dll.cpp
@@ -30,7 +30,7 @@
      7 November 2018 -- assure identical legacy and extended flags in laszip_write_point()
     20 October 2018 -- changed (U8*) to (const U8*) for all out->put___() calls
      5 October 2018 -- corrected 'is_empty' return value in laszip_inside_rectangle()
-    29 September 2018 -- laszip_prepare_point_for_write() sets extended_point_type 
+    29 September 2018 -- laszip_prepare_point_for_write() sets extended_point_type
     19 September 2018 -- removed tuples and triple support from attributes
      7 September 2018 -- replaced calls to _strdup with calls to the LASCopyString macro
      6 April 2018 -- added zero() function to laszip_dll struct to fix memory leak
@@ -129,7 +129,14 @@ private:
   BOOL first;
 };
 
-typedef struct laszip_dll {
+typedef struct laszip_message_callback_data
+{
+  laszip_message_handler callback;
+  void* user_data;
+} laszip_message_callback_data_struct;
+
+typedef struct laszip_dll
+{
   laszip_header_struct header;
   I64 p_count;
   I64 npoints;
@@ -165,6 +172,7 @@ typedef struct laszip_dll {
   I32 start_NIR_band;
   laszip_dll_inventory* inventory;
   std::vector<void *> buffers;
+  laszip_message_callback_data_struct* message_callback_data;
 
   void zero()
   {
@@ -202,6 +210,7 @@ typedef struct laszip_dll {
     start_flags_and_channel = 0;
     start_NIR_band = 0;
     inventory = NULL;
+    message_callback_data = NULL;
   };
 } laszip_dll_struct;
 
@@ -223,6 +232,218 @@ laszip_get_version(
   }
   catch (...)
   {
+    return 1;
+  }
+
+  return 0;
+}
+
+/*---------------------------------------------------------------------------*/
+static void
+laszip_message_func(
+    LAS_MESSAGE_TYPE                   type
+    , const char*                      msg
+    , void*                            user_data
+)
+{
+  if (user_data == 0) return;
+  laszip_dll_struct* laszip_dll = (laszip_dll_struct*)user_data;
+  if (laszip_dll->message_callback_data == 0) return;
+  if (laszip_dll->message_callback_data->callback == 0) return;
+
+  enum laszip_message_type message_type;
+  switch (type)
+  {
+  case LAS_MESSAGE_TYPE::LAS_DEBUG:
+    message_type = laszip_message_type::laszip_DEBUG;
+    break;
+  case LAS_MESSAGE_TYPE::LAS_VERY_VERBOSE:
+    message_type = laszip_message_type::laszip_VERY_VERBOSE;
+    break;
+  case LAS_MESSAGE_TYPE::LAS_VERBOSE:
+    message_type = laszip_message_type::laszip_VERBOSE;
+    break;
+  case LAS_MESSAGE_TYPE::LAS_INFO:
+    message_type = laszip_message_type::laszip_INFO;
+    break;
+  case LAS_MESSAGE_TYPE::LAS_WARNING:
+    message_type = laszip_message_type::laszip_WARNING;
+    break;
+  case LAS_MESSAGE_TYPE::LAS_SERIOUS_WARNING:
+    message_type = laszip_message_type::laszip_SERIOUS_WARNING;
+    break;
+  case LAS_MESSAGE_TYPE::LAS_ERROR:
+    message_type = laszip_message_type::laszip_ERROR;
+    break;
+  case LAS_MESSAGE_TYPE::LAS_FATAL_ERROR:
+    message_type = laszip_message_type::laszip_FATAL_ERROR;
+    break;
+  }
+  laszip_dll->message_callback_data->callback(
+    message_type, msg, laszip_dll->message_callback_data->user_data);
+}
+
+/*---------------------------------------------------------------------------*/
+LASZIP_API laszip_I32
+laszip_set_error_handler(
+    laszip_POINTER*                    pointer
+    , laszip_message_handler           callback
+    , void*                            user_data
+)
+{
+  if (pointer == 0) return 1;
+  laszip_dll_struct* laszip_dll = (laszip_dll_struct*)pointer;
+
+  try
+  {
+    if (laszip_dll->message_callback_data)
+    {
+      free(laszip_dll->message_callback_data);
+    }
+    laszip_dll->message_callback_data = new laszip_message_callback_data_struct;
+    if (laszip_dll->message_callback_data == 0)
+    {
+      sprintf(laszip_dll->error, "memory allocation error in laszip_set_error_handler");
+      return 1;
+    }
+    laszip_dll->message_callback_data->callback = callback;
+    laszip_dll->message_callback_data->user_data = user_data;
+    set_las_message_handler(laszip_message_func, pointer);
+  }
+  catch (...)
+  {
+    sprintf(laszip_dll->error, "internal error in laszip_set_error_handler");
+    return 1;
+  }
+
+  return 0;
+}
+
+/*---------------------------------------------------------------------------*/
+LASZIP_API laszip_I32
+laszip_unset_las_message_handler
+(
+    laszip_POINTER*                    pointer
+)
+{
+  if (pointer == 0) return 1;
+  laszip_dll_struct* laszip_dll = (laszip_dll_struct*)pointer;
+  try
+  {
+    unset_las_message_handler();
+    if (laszip_dll->message_callback_data)
+    {
+      free(laszip_dll->message_callback_data);
+      laszip_dll->message_callback_data = NULL;
+    }
+  }
+  catch (...)
+  {
+    sprintf(laszip_dll->error, "internal error in laszip_unset_las_message_handler");
+    return 1;
+  }
+
+  return 0;
+}
+
+/*---------------------------------------------------------------------------*/
+LASZIP_API laszip_I32
+laszip_set_las_message_log_level
+(
+    laszip_POINTER                     pointer
+    , enum laszip_message_type         log_level
+)
+{
+  if (pointer == 0) return 1;
+  laszip_dll_struct* laszip_dll = (laszip_dll_struct*)pointer;
+
+  try
+  {
+    enum LAS_MESSAGE_TYPE message_type;
+    switch (log_level)
+    {
+    case laszip_message_type::laszip_DEBUG:
+      message_type = LAS_MESSAGE_TYPE::LAS_DEBUG;
+      break;
+    case laszip_message_type::laszip_VERY_VERBOSE:
+      message_type = LAS_MESSAGE_TYPE::LAS_VERY_VERBOSE;
+      break;
+    case laszip_message_type::laszip_VERBOSE:
+      message_type = LAS_MESSAGE_TYPE::LAS_VERBOSE;
+      break;
+    case laszip_message_type::laszip_INFO:
+      message_type = LAS_MESSAGE_TYPE::LAS_INFO;
+      break;
+    case laszip_message_type::laszip_WARNING:
+      message_type = LAS_MESSAGE_TYPE::LAS_WARNING;
+      break;
+    case laszip_message_type::laszip_SERIOUS_WARNING:
+      message_type = LAS_MESSAGE_TYPE::LAS_SERIOUS_WARNING;
+      break;
+    case laszip_message_type::laszip_ERROR:
+      message_type = LAS_MESSAGE_TYPE::LAS_ERROR;
+      break;
+    case laszip_message_type::laszip_FATAL_ERROR:
+      message_type = LAS_MESSAGE_TYPE::LAS_FATAL_ERROR;
+      break;
+    }
+    set_message_log_level(message_type);
+  }
+  catch (...)
+  {
+    sprintf(laszip_dll->error, "internal error in laszip_set_las_message_log_level");
+    return 1;
+  }
+
+  return 0;
+}
+
+/*---------------------------------------------------------------------------*/
+LASZIP_API laszip_I32
+laszip_get_las_message_log_level
+(
+    laszip_POINTER                     pointer
+    , enum laszip_message_type*        log_level
+)
+{
+  if (pointer == 0) return 1;
+  laszip_dll_struct* laszip_dll = (laszip_dll_struct*)pointer;
+  if (log_level == 0) return 1;
+
+  try
+  {
+    enum LAS_MESSAGE_TYPE message_type = get_message_log_level();
+    switch (message_type)
+    {
+    case LAS_MESSAGE_TYPE::LAS_DEBUG:
+      *log_level = laszip_message_type::laszip_DEBUG;
+      break;
+    case LAS_MESSAGE_TYPE::LAS_VERY_VERBOSE:
+      *log_level = laszip_message_type::laszip_VERY_VERBOSE;
+      break;
+    case LAS_MESSAGE_TYPE::LAS_VERBOSE:
+      *log_level = laszip_message_type::laszip_VERBOSE;
+      break;
+    case LAS_MESSAGE_TYPE::LAS_INFO:
+      *log_level = laszip_message_type::laszip_INFO;
+      break;
+    case LAS_MESSAGE_TYPE::LAS_WARNING:
+      *log_level = laszip_message_type::laszip_WARNING;
+      break;
+    case LAS_MESSAGE_TYPE::LAS_SERIOUS_WARNING:
+      *log_level = laszip_message_type::laszip_SERIOUS_WARNING;
+      break;
+    case LAS_MESSAGE_TYPE::LAS_ERROR:
+      *log_level = laszip_message_type::laszip_ERROR;
+      break;
+    case LAS_MESSAGE_TYPE::LAS_FATAL_ERROR:
+      *log_level = laszip_message_type::laszip_FATAL_ERROR;
+      break;
+    }
+  }
+  catch (...)
+  {
+    sprintf(laszip_dll->error, "internal error in laszip_get_las_message_log_level");
     return 1;
   }
 
@@ -441,6 +662,13 @@ laszip_clean(
         free(laszip_dll->buffers[i]);
       }
       laszip_dll->buffers.clear();
+    }
+
+    // dealloc message callback data
+
+    if (laszip_dll->message_callback_data)
+    {
+      free(laszip_dll->message_callback_data);
     }
 
     // zero every field of the laszip_dll struct
@@ -2165,7 +2393,7 @@ laszip_prepare_point_for_write(
     // must *not* be set for the old point type 5 or lower
 
     laszip_dll->point.extended_point_type = 0;
-    
+
     // we are *not* operating in compatibility mode
 
     laszip_dll->compatibility_mode = FALSE;
@@ -2906,7 +3134,7 @@ laszip_open_writer(
     laszip_dll->file = _wfopen(utf16_file_name, L"wb");
     delete [] utf16_file_name;
 #else
-	laszip_dll->file = fopen(file_name, "wb");
+    laszip_dll->file = fopen(file_name, "wb");
 #endif
 
     if (laszip_dll->file == 0)
@@ -2978,13 +3206,13 @@ laszip_open_writer(
 
     if (laszip_dll->lax_create)
     {
-	    // create spatial indexing information using cell_size = 100.0f and threshold = 1000
+      // create spatial indexing information using cell_size = 100.0f and threshold = 1000
 
-	    LASquadtree* lasquadtree = new LASquadtree;
-	    lasquadtree->setup(laszip_dll->header.min_x, laszip_dll->header.max_x, laszip_dll->header.min_y, laszip_dll->header.max_y, 100.0f);
+      LASquadtree* lasquadtree = new LASquadtree;
+      lasquadtree->setup(laszip_dll->header.min_x, laszip_dll->header.max_x, laszip_dll->header.min_y, laszip_dll->header.max_y, 100.0f);
 
-	    laszip_dll->lax_index = new LASindex;
-	    laszip_dll->lax_index->prepare(lasquadtree, 1000);
+      laszip_dll->lax_index = new LASindex;
+      laszip_dll->lax_index->prepare(lasquadtree, 1000);
 
       // copy the file name for later
 
@@ -3330,7 +3558,7 @@ laszip_close_writer(
     delete laszip_dll->streamout;
     laszip_dll->streamout = 0;
 
-	  if (laszip_dll->file)
+    if (laszip_dll->file)
     {
       fclose(laszip_dll->file);
       laszip_dll->file = 0;
@@ -3963,7 +4191,7 @@ laszip_read_header(
   }
 
   // create point's item pointers
-  
+
   if (laszip_dll->point_items)
   {
     delete [] laszip_dll->point_items;
@@ -4298,7 +4526,7 @@ laszip_open_reader(
     laszip_dll->file = _wfopen(utf16_file_name, L"rb");
     delete [] utf16_file_name;
 #else
-	laszip_dll->file = fopen(file_name, "rb");
+    laszip_dll->file = fopen(file_name, "rb");
 #endif
 
     if (laszip_dll->file == 0)
@@ -4696,7 +4924,7 @@ laszip_close_reader(
       laszip_dll->lax_index = 0;
     }
 
-  	if (laszip_dll->file)
+    if (laszip_dll->file)
     {
       fclose(laszip_dll->file);
       laszip_dll->file = 0;


### PR DESCRIPTION
Closes #98.

Notice that due to the underlying implementation it is neither thread-safe nor dedicated. All instances of laszip_POINTER share the same callback, user data and log level - whoever sets it last.