### PR TITLE
Fix MSVC compilation with /std:c++17 (or later)

### DIFF
--- a/src/laszip_dll.cpp
+++ b/src/laszip_dll.cpp
@@ -49,6 +49,11 @@
 #define LASZIP_DYN_LINK
 #define LASZIP_SOURCE
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#define _HAS_STD_BYTE 0
+
 #include <limits>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
This fixes the two MSVC errors with recent C++ standard set on MSVC

1. error C2872: 'byte': ambiguous symbol
2. warning C4003: not enough arguments for function-like macro invocation 'max' wich then leads to subsequent syntax errors