### PR TITLE
Avoid namespace pollution

### DIFF
--- a/dll/laszip_api.h
+++ b/dll/laszip_api.h
@@ -586,15 +586,14 @@ laszip_unload_dll
 #include <fstream.h>
 #else
 #include <istream>
-#include <fstream>
-using namespace std;
+#include <ostream>
 #endif
 
 /*---------------------------------------------------------------------------*/
 LASZIP_API laszip_I32
 laszip_open_reader_stream(
     laszip_POINTER                     pointer
-    , istream&                         stream
+    , std::istream&                    stream
     , laszip_BOOL*                     is_compressed
 );
 
@@ -602,7 +601,7 @@ laszip_open_reader_stream(
 LASZIP_API laszip_I32
 laszip_open_writer_stream(
     laszip_POINTER                     pointer
-    , ostream&                         stream
+    , std::ostream&                    stream
     , laszip_BOOL                      compress
     , laszip_BOOL                      do_not_write_header
 );

--- a/src/laszip_dll.cpp
+++ b/src/laszip_dll.cpp
@@ -4720,7 +4720,7 @@ laszip_close_reader(
 LASZIP_API laszip_I32
 laszip_open_reader_stream(
     laszip_POINTER                     pointer
-    , istream&                         stream
+    , std::istream&                    stream
     , laszip_BOOL*                     is_compressed
 )
 {
@@ -4777,7 +4777,7 @@ laszip_open_reader_stream(
 LASZIP_API laszip_I32
 laszip_open_writer_stream(
     laszip_POINTER                     pointer
-    , ostream&                         stream
+    , std::ostream&                    stream
     , laszip_BOOL                      compress
     , laszip_BOOL                      do_not_write_header
 )


### PR DESCRIPTION
It's considered bad practice to have `using namespace std;` in a header file, see https://isocpp.org/wiki/faq/coding-standards#using-namespace-std.

Additionally, include the proper header file for std::ostream - being \<ostream\>.