### PR TITLE
resolve gcc compiler warnings in -Wall mode

### DIFF
--- a/src/laszip_dll.cpp
+++ b/src/laszip_dll.cpp
@@ -1186,7 +1186,7 @@ laszip_set_point(
         }
         else
         {
-          snprintf(laszip_dll->error, sizeof(laszip_dll->error), "target point has %ld extra bytes but source point has %ld", laszip_dll->point.num_extra_bytes, point->num_extra_bytes);
+          snprintf(laszip_dll->error, sizeof(laszip_dll->error), "target point has %ld extra bytes but source point has %ld", (long) laszip_dll->point.num_extra_bytes, (long) point->num_extra_bytes);
           return 1;
         }
       }
@@ -2008,7 +2008,7 @@ laszip_prepare_header_for_write(
     {
       if (laszip_dll->header.number_of_point_records != 0)
       {
-        snprintf(laszip_dll->error, sizeof(laszip_dll->error), "inconsistent number_of_point_records %lu and extended_number_of_point_records %llu", laszip_dll->header.number_of_point_records, laszip_dll->header.extended_number_of_point_records);
+        snprintf(laszip_dll->error, sizeof(laszip_dll->error), "inconsistent number_of_point_records %lu and extended_number_of_point_records %llu", (long) laszip_dll->header.number_of_point_records, (unsigned long long) laszip_dll->header.extended_number_of_point_records);
         return 1;
       }
       else if (laszip_dll->header.extended_number_of_point_records <= U32_MAX)
@@ -2022,7 +2022,7 @@ laszip_prepare_header_for_write(
       {
         if (laszip_dll->header.number_of_points_by_return[i] != 0)
         {
-          snprintf(laszip_dll->error, sizeof(laszip_dll->error), "inconsistent number_of_points_by_return[%u] %lu and extended_number_of_points_by_return[%u] %llu", i, laszip_dll->header.number_of_points_by_return[i], i, laszip_dll->header.extended_number_of_points_by_return[i]);
+          snprintf(laszip_dll->error, sizeof(laszip_dll->error), "inconsistent number_of_points_by_return[%u] %lu and extended_number_of_points_by_return[%u] %llu", i, (unsigned long) laszip_dll->header.number_of_points_by_return[i], i, (unsigned long long) laszip_dll->header.extended_number_of_points_by_return[i]);
           return 1;
         }
         else if (laszip_dll->header.extended_number_of_points_by_return[i] <= U32_MAX)
@@ -2067,7 +2067,7 @@ laszip_prepare_point_for_write(
 
       if (laszip_dll->header.extended_number_of_point_records > U32_MAX)
       {
-        snprintf(laszip_dll->error, sizeof(laszip_dll->error), "extended_number_of_point_records of %llu is too much for 32-bit counters of compatibility mode", laszip_dll->header.extended_number_of_point_records);
+        snprintf(laszip_dll->error, sizeof(laszip_dll->error), "extended_number_of_point_records of %llu is too much for 32-bit counters of compatibility mode", (unsigned long long) laszip_dll->header.extended_number_of_point_records);
         return 1;
       }
 
@@ -2728,7 +2728,7 @@ laszip_write_header(
     {
       if (laszip_dll->header.start_of_waveform_data_packet_record != 0)
       {
-        snprintf(laszip_dll->warning, sizeof(laszip_dll->warning), "header.start_of_waveform_data_packet_record is %llu. writing 0 instead.", laszip_dll->header.start_of_waveform_data_packet_record);
+        snprintf(laszip_dll->warning, sizeof(laszip_dll->warning), "header.start_of_waveform_data_packet_record is %llu. writing 0 instead.", (unsigned long long) laszip_dll->header.start_of_waveform_data_packet_record);
         laszip_dll->header.start_of_waveform_data_packet_record = 0;
       }
       try { laszip_dll->streamout->put64bitsLE((const U8*)&(laszip_dll->header.start_of_waveform_data_packet_record)); } catch(...)
@@ -4647,7 +4647,7 @@ laszip_seek_point(
     // seek to the point
     if (!laszip_dll->reader->seek((U32)laszip_dll->p_count, (U32)index))
     {
-      snprintf(laszip_dll->error, sizeof(laszip_dll->error), "seeking from index %lld to index %lld for file with %lld points", laszip_dll->p_count, index, laszip_dll->npoints);
+      snprintf(laszip_dll->error, sizeof(laszip_dll->error), "seeking from index %lld to index %lld for file with %lld points", (long long) laszip_dll->p_count, (long long) index, (long long) laszip_dll->npoints);
       return 1;
     }
     laszip_dll->p_count = index;

--- a/src/laszip_dll.cpp
+++ b/src/laszip_dll.cpp
@@ -1186,7 +1186,7 @@ laszip_set_point(
         }
         else
         {
-          snprintf(laszip_dll->error, sizeof(laszip_dll->error), "target point has %ld extra bytes but source point has %ld", (long) laszip_dll->point.num_extra_bytes, (long) point->num_extra_bytes);
+          snprintf(laszip_dll->error, sizeof(laszip_dll->error), "target point has %ld extra bytes but source point has %ld", static_cast<long>(laszip_dll->point.num_extra_bytes), static_cast<long>(point->num_extra_bytes));
           return 1;
         }
       }
@@ -2008,7 +2008,7 @@ laszip_prepare_header_for_write(
     {
       if (laszip_dll->header.number_of_point_records != 0)
       {
-        snprintf(laszip_dll->error, sizeof(laszip_dll->error), "inconsistent number_of_point_records %lu and extended_number_of_point_records %llu", (long) laszip_dll->header.number_of_point_records, (unsigned long long) laszip_dll->header.extended_number_of_point_records);
+        snprintf(laszip_dll->error, sizeof(laszip_dll->error), "inconsistent number_of_point_records %lu and extended_number_of_point_records %llu", static_cast<unsigned long>(laszip_dll->header.number_of_point_records), static_cast<unsigned long long>(laszip_dll->header.extended_number_of_point_records));
         return 1;
       }
       else if (laszip_dll->header.extended_number_of_point_records <= U32_MAX)
@@ -2022,7 +2022,7 @@ laszip_prepare_header_for_write(
       {
         if (laszip_dll->header.number_of_points_by_return[i] != 0)
         {
-          snprintf(laszip_dll->error, sizeof(laszip_dll->error), "inconsistent number_of_points_by_return[%u] %lu and extended_number_of_points_by_return[%u] %llu", i, (unsigned long) laszip_dll->header.number_of_points_by_return[i], i, (unsigned long long) laszip_dll->header.extended_number_of_points_by_return[i]);
+          snprintf(laszip_dll->error, sizeof(laszip_dll->error), "inconsistent number_of_points_by_return[%u] %lu and extended_number_of_points_by_return[%u] %llu", i, static_cast<unsigned long>(laszip_dll->header.number_of_points_by_return[i]), i, static_cast<unsigned long long>(laszip_dll->header.extended_number_of_points_by_return[i]));
           return 1;
         }
         else if (laszip_dll->header.extended_number_of_points_by_return[i] <= U32_MAX)
@@ -2067,7 +2067,7 @@ laszip_prepare_point_for_write(
 
       if (laszip_dll->header.extended_number_of_point_records > U32_MAX)
       {
-        snprintf(laszip_dll->error, sizeof(laszip_dll->error), "extended_number_of_point_records of %llu is too much for 32-bit counters of compatibility mode", (unsigned long long) laszip_dll->header.extended_number_of_point_records);
+        snprintf(laszip_dll->error, sizeof(laszip_dll->error), "extended_number_of_point_records of %llu is too much for 32-bit counters of compatibility mode", static_cast<unsigned long long>(laszip_dll->header.extended_number_of_point_records));
         return 1;
       }
 
@@ -2728,7 +2728,7 @@ laszip_write_header(
     {
       if (laszip_dll->header.start_of_waveform_data_packet_record != 0)
       {
-        snprintf(laszip_dll->warning, sizeof(laszip_dll->warning), "header.start_of_waveform_data_packet_record is %llu. writing 0 instead.", (unsigned long long) laszip_dll->header.start_of_waveform_data_packet_record);
+        snprintf(laszip_dll->warning, sizeof(laszip_dll->warning), "header.start_of_waveform_data_packet_record is %llu. writing 0 instead.", static_cast<unsigned long long>(laszip_dll->header.start_of_waveform_data_packet_record));
         laszip_dll->header.start_of_waveform_data_packet_record = 0;
       }
       try { laszip_dll->streamout->put64bitsLE((const U8*)&(laszip_dll->header.start_of_waveform_data_packet_record)); } catch(...)
@@ -4647,7 +4647,7 @@ laszip_seek_point(
     // seek to the point
     if (!laszip_dll->reader->seek((U32)laszip_dll->p_count, (U32)index))
     {
-      snprintf(laszip_dll->error, sizeof(laszip_dll->error), "seeking from index %lld to index %lld for file with %lld points", (long long) laszip_dll->p_count, (long long) index, (long long) laszip_dll->npoints);
+      snprintf(laszip_dll->error, sizeof(laszip_dll->error), "seeking from index %lld to index %lld for file with %lld points", static_cast<long long>(laszip_dll->p_count), static_cast<long long>(index), static_cast<long long>(laszip_dll->npoints));
       return 1;
     }
     laszip_dll->p_count = index;


### PR DESCRIPTION
No functional change, just appeasing the compiler.

```
$ gcc --version
gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0
...
$ cmake --fresh -DCMAKE_CXX_FLAGS=-Wall ..
...
[  4%] Building CXX object src/CMakeFiles/laszip.dir/laszip_dll.cpp.o
/home/nigel.stewart/dev/laszip/src/laszip_dll.cpp: In function ‘laszip_I32 laszip_set_point(laszip_POINTER, const laszip_point_struct*)’:
/home/nigel.stewart/dev/laszip/src/laszip_dll.cpp:1189:86: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘laszip_I32’ {aka ‘int’} [-Wformat=]
 1189 |           snprintf(laszip_dll->error, sizeof(laszip_dll->error), "target point has %ld extra bytes but source point has %ld", laszip_dll->point.num_extra_bytes, point->num_extra_bytes);
      |                                                                                    ~~^                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                      |                                                          |
      |                                                                                      long int                                                   laszip_I32 {aka int}
      |                                                                                    %d
/home/nigel.stewart/dev/laszip/src/laszip_dll.cpp:1189:123: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 5 has type ‘laszip_I32’ {aka ‘int’} [-Wformat=]
 1189 |           snprintf(laszip_dll->error, sizeof(laszip_dll->error), "target point has %ld extra bytes but source point has %ld", laszip_dll->point.num_extra_bytes, point->num_extra_bytes);
      |                                                                                                                         ~~^                                      ~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                                           |                                             |
      |                                                                                                                           long int                                      laszip_I32 {aka int}
      |                                                                                                                         %d
/home/nigel.stewart/dev/laszip/src/laszip_dll.cpp: In function ‘I32 laszip_prepare_header_for_write(laszip_dll_struct*)’:
/home/nigel.stewart/dev/laszip/src/laszip_dll.cpp:2011:104: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 4 has type ‘laszip_U32’ {aka ‘unsigned int’} [-Wformat=]
 2011 |         snprintf(laszip_dll->error, sizeof(laszip_dll->error), "inconsistent number_of_point_records %lu and extended_number_of_point_records %llu", laszip_dll->header.number_of_point_records, laszip_dll->header.extended_number_of_point_records);
      |                                                                                                      ~~^                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                        |                                                                |
      |                                                                                                        long unsigned int                                                laszip_U32 {aka unsigned int}
      |                                                                                                      %u
/home/nigel.stewart/dev/laszip/src/laszip_dll.cpp:2011:146: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 5 has type ‘laszip_U64’ {aka ‘long unsigned int’} [-Wformat=]
 2011 |         snprintf(laszip_dll->error, sizeof(laszip_dll->error), "inconsistent number_of_point_records %lu and extended_number_of_point_records %llu", laszip_dll->header.number_of_point_records, laszip_dll->header.extended_number_of_point_records);
      |                                                                                                                                               ~~~^                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                                                                  |                                                                  |
      |                                                                                                                                                  long long unsigned int                                             laszip_U64 {aka long unsigned int}
      |                                                                                                                                               %lu
/home/nigel.stewart/dev/laszip/src/laszip_dll.cpp:2025:113: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 5 has type ‘laszip_U32’ {aka ‘unsigned int’} [-Wformat=]
 2025 |           snprintf(laszip_dll->error, sizeof(laszip_dll->error), "inconsistent number_of_points_by_return[%u] %lu and extended_number_of_points_by_return[%u] %llu", i, laszip_dll->header.number_of_points_by_return[i], i, laszip_dll->header.extended_number_of_points_by_return[i]);
      |                                                                                                               ~~^                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                                 |                                                                                                      |
      |                                                                                                                 long unsigned int                                                                                      laszip_U32 {aka unsigned int}
      |                                                                                                               %u
/home/nigel.stewart/dev/laszip/src/laszip_dll.cpp:2025:162: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 7 has type ‘laszip_U64’ {aka ‘long unsigned int’} [-Wformat=]
 2025 |           snprintf(laszip_dll->error, sizeof(laszip_dll->error), "inconsistent number_of_points_by_return[%u] %lu and extended_number_of_points_by_return[%u] %llu", i, laszip_dll->header.number_of_points_by_return[i], i, laszip_dll->header.extended_number_of_points_by_return[i]);
      |                                                                                                                                                               ~~~^                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                                                                                  |                                                                                                                   |
      |                                                                                                                                                                  long long unsigned int                                                                                              laszip_U64 {aka long unsigned int}
      |                                                                                                                                                               %lu
/home/nigel.stewart/dev/laszip/src/laszip_dll.cpp: In function ‘I32 laszip_prepare_point_for_write(laszip_dll_struct*, laszip_BOOL)’:
/home/nigel.stewart/dev/laszip/src/laszip_dll.cpp:2070:104: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 4 has type ‘laszip_U64’ {aka ‘long unsigned int’} [-Wformat=]
 2070 |         snprintf(laszip_dll->error, sizeof(laszip_dll->error), "extended_number_of_point_records of %llu is too much for 32-bit counters of compatibility mode", laszip_dll->header.extended_number_of_point_records);
      |                                                                                                     ~~~^                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                        |                                                                            |
      |                                                                                                        long long unsigned int                                                       laszip_U64 {aka long unsigned int}
      |
 ```