### PR TITLE
Fix include issue

### DIFF
--- a/dll/laszip_api.h
+++ b/dll/laszip_api.h
@@ -57,7 +57,7 @@
 #include <laszip/laszip_api_version.h>
 #include <laszip/laszip_common.h>
 #else
-#include <laszip_common.h>
+#include <laszip/laszip_common.h>
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
When using `#include <laszip/laszip_api.h>` in my project, the compilation fails with the following error since LASzip 3.5.0:
```
error: 'laszip_common.h' file not found with <angled> include; use "quotes" instead
   60 | #include <laszip_common.h>
      |          ^
```

The fix in this PR works for me, and judging by how the include is the same in line 58 when `LASZIP_API_VERSION` is defined, I believe this may also be the actual fix.