### PR TITLE
Let C++ and C standard be configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,6 @@ string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 
 set(ROOT_DIR "${PROJECT_SOURCE_DIR}")
 
-if (NOT CMAKE_C_STANDARD)
-    set(CMAKE_C_STANDARD 99)
-    set(CMAKE_C_STANDARD_REQUIRED ON)
-endif()
 
 if(CMAKE_GNU_COMPILER_ID OR CMAKE_Clang_COMPILER_ID)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-security -Wno-format-truncation")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,18 +5,9 @@ string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 
 set(ROOT_DIR "${PROJECT_SOURCE_DIR}")
 
-if (NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 if (NOT CMAKE_C_STANDARD)
     set(CMAKE_C_STANDARD 99)
     set(CMAKE_C_STANDARD_REQUIRED ON)
-endif()
-
-if (MSVC)
-  add_compile_options("/std:c++17")
 endif()
 
 if(CMAKE_GNU_COMPILER_ID OR CMAKE_Clang_COMPILER_ID)
@@ -135,4 +126,3 @@ add_subdirectory(dll)
 
 #
 add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
-

--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -64,8 +64,9 @@ macro(LASZIP_ADD_LIBRARY _name)
         CLEAN_DIRECT_OUTPUT 1
         FOLDER Libraries
         CMAKE_CXX_STANDARD_REQUIRED ON
+        CMAKE_C_STANDARD_REQUIRED ON
     )
-    target_compile_features(${_name} PRIVATE cxx_std_17)
+    target_compile_features(${_name} PRIVATE cxx_std_17 c_std_99)
 
     install(TARGETS ${_name}
         EXPORT LASZIPTargets

--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -63,7 +63,9 @@ macro(LASZIP_ADD_LIBRARY _name)
         SOVERSION ${LASZIP_COMPATIBILITY_VERSION}
         CLEAN_DIRECT_OUTPUT 1
         FOLDER Libraries
+        CMAKE_CXX_STANDARD_REQUIRED ON
     )
+    target_compile_features(${_name} PRIVATE cxx_std_17)
 
     install(TARGETS ${_name}
         EXPORT LASZIPTargets


### PR DESCRIPTION
Hello!

As we are reviewing the inclusion of laszip 3.5.0 in the PR https://github.com/conan-io/conan-center-index/pull/30657. It was noted the hardcoded use of C++17 twice in your CMake scripts, which results in a non-flexible way to use C++20 or later. 

The current CI use in Conan Center has a range of supported C++ standards, including C++20, which can be configured by consumers. 

This PR flexibilizes the way to configure the C and C++ standards consumed by libraries/targets laszip and laszip_api, by asking to CMake configure C++17 as the minimum version, so users can use C++20 as well.

References:
- https://cmake.org/cmake/help/latest/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html#high-level-meta-features-indicating-c-standard-support
- https://cmake.org/cmake/help/latest/command/target_compile_features.html#command:target_compile_features


Let me know if you need further information. Regards! 