### PR TITLE
Fix stat_las() not compiling with MinGW

### DIFF
--- a/src/mydefs.hpp
+++ b/src/mydefs.hpp
@@ -495,7 +495,7 @@ inline int stat_las(const char* path, las_stat_t* buf) {
 #if defined(_WIN32) && !defined(__MINGW32__)
   return _stati64(path, buf);
 #elif defined(__MINGW32__)
-  return stat64(path, buf);
+  return _stat64(path, buf);
 #else
   return stat(path, buf);
 #endif


### PR DESCRIPTION
`las_stat_t` is typedef'd to `struct _stat64` on `_WIN32` (`mydefs.hpp:96`), which covers MinGW as well, but the MinGW branch of `stat_las()` calls `stat64()`. On mingw-w64 those are distinct types, so the function does not compile:

```
mydefs.hpp:498:23: error: cannot convert 'las_stat_t*' {aka '_stat64*'} to 'stat64*'
```

This bites even when `stat_las()` is never called, because it is `inline` and its body is still type-checked wherever `mydefs.hpp` is included — which is every translation unit in the library.

mingw-w64 provides `_stat64()` taking `struct _stat64*`, matching the typedef and the MSVC branch directly above it.

Verified with GCC 15.2 (mingw-w64) at C++20: before the change none of the 12 core `.cpp` files compile; after it, all of them do.
